### PR TITLE
データベースをホストに永続化する

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -104,3 +104,6 @@ venv.bak/
 
 # mypy
 .mypy_cache/
+
+# docker data volumes
+db-store/

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,6 @@ version: "3"
 services:
   app:
     build: ./app
-#    working_dir: /usr/src/app
     command: python manage.py runserver 0.0.0.0:8000
     volumes:
       - ./app:/usr/src/app
@@ -13,9 +12,13 @@ services:
       - db
   db:
     image: postgres:10-alpine
+    volumes:
+      - db-store:/var/lib/postgresql/data
     environment:
       - POSTGRES_USER=postgres
       - POSTGRES_PASSWORD=password
       - PGPASSWORD=password
       - POSTGRES_DB=development
       - DATABASE_HOST=localhost
+volumes:
+  db-store:


### PR DESCRIPTION
## 概要
data-volumeを作っていないため、コンテナを落とすとDBのスキーマが消失してしまう。
この問題に対応した。

## 確認方法
```
$docker-compose build

$ docker-compose up -d
$ docker-compose exec app python manage.py migrate

$docker-compose down

$docker-compose up -d
```
- [x] `docker-compose down` 前後でDBが保たれていること
- [x] プロジェクト内にDBスキーマをマウントするようにしたので、それらが.gitignoreされていること

・ボリュームを削除しながらコンテナを落とすコマンド
```
$ docker-compose down --volume all
```

## 備考
名前付きボリュームをdocker-composeによって作っているため、プロジェクトのディレクトリ名がボリューム名になる。
そのため、過去に同名のプロジェクト(ディレクトリ)名でボリュームを作っていた場合、混同してしまうので注意。